### PR TITLE
Add support for fetchesMessages

### DIFF
--- a/java/src/main/java/org/whispersystems/textsecure/api/TextSecureAccountManager.java
+++ b/java/src/main/java/org/whispersystems/textsecure/api/TextSecureAccountManager.java
@@ -122,11 +122,11 @@ public class TextSecureAccountManager {
    * @throws IOException
    */
   public void verifyAccount(String verificationCode, String signalingKey,
-                            boolean supportsSms, int axolotlRegistrationId)
+                            boolean supportsSms, boolean fetchesMessages, int axolotlRegistrationId)
       throws IOException
   {
     this.pushServiceSocket.verifyAccount(verificationCode, signalingKey,
-                                         supportsSms, axolotlRegistrationId);
+                                         supportsSms, fetchesMessages, axolotlRegistrationId);
   }
 
   /**

--- a/java/src/main/java/org/whispersystems/textsecure/internal/push/AccountAttributes.java
+++ b/java/src/main/java/org/whispersystems/textsecure/internal/push/AccountAttributes.java
@@ -27,12 +27,17 @@ public class AccountAttributes {
   private boolean supportsSms;
 
   @JsonProperty
+  private boolean fetchesMessages;
+
+
+  @JsonProperty
   private int     registrationId;
 
-  public AccountAttributes(String signalingKey, boolean supportsSms, int registrationId) {
-    this.signalingKey   = signalingKey;
-    this.supportsSms    = supportsSms;
-    this.registrationId = registrationId;
+  public AccountAttributes(String signalingKey, boolean supportsSms, boolean fetchesMessages, int registrationId) {
+    this.signalingKey    = signalingKey;
+    this.supportsSms     = supportsSms;
+    this.fetchesMessages = fetchesMessages;
+    this.registrationId  = registrationId;
   }
 
   public AccountAttributes() {}
@@ -48,4 +53,6 @@ public class AccountAttributes {
   public int getRegistrationId() {
     return registrationId;
   }
+
+  public boolean isFetchesMessages() { return fetchesMessages; }
 }

--- a/java/src/main/java/org/whispersystems/textsecure/internal/push/PushServiceSocket.java
+++ b/java/src/main/java/org/whispersystems/textsecure/internal/push/PushServiceSocket.java
@@ -112,10 +112,10 @@ public class PushServiceSocket {
   }
 
   public void verifyAccount(String verificationCode, String signalingKey,
-                            boolean supportsSms, int registrationId)
+                            boolean supportsSms, boolean fetchesMessages, int registrationId)
       throws IOException
   {
-    AccountAttributes signalingKeyEntity = new AccountAttributes(signalingKey, supportsSms, registrationId);
+    AccountAttributes signalingKeyEntity = new AccountAttributes(signalingKey, supportsSms, fetchesMessages, registrationId);
     makeRequest(String.format(VERIFY_ACCOUNT_PATH, verificationCode),
                 "PUT", JsonUtil.toJson(signalingKeyEntity));
   }


### PR DESCRIPTION
Currently libtextsecure doesn't allow devices without a GCM Id to fetch mesages.
This change adds the fetchesMessages flag in the verifyAccount methods of the API and PushServiceSocket as well as in the AccountAttributes model.