### PR TITLE
Fix provisioning flow

### DIFF
--- a/java/src/main/java/org/whispersystems/textsecure/internal/push/ProvisioningMessage.java
+++ b/java/src/main/java/org/whispersystems/textsecure/internal/push/ProvisioningMessage.java
@@ -1,7 +1,10 @@
 package org.whispersystems.textsecure.internal.push;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class ProvisioningMessage {
 
+  @JsonProperty
   private String body;
 
   public ProvisioningMessage(String body) {


### PR DESCRIPTION
Make ProvisionMessage serializable. Previously, the lack of jackson
annotations caused this object to serialize as empty string, which
elicits a 500 from the server.