### PR TITLE
add /v1/accounts/wsc/ endpoint support

### DIFF
--- a/java/src/main/java/org/whispersystems/textsecure/api/TextSecureAccountManager.java
+++ b/java/src/main/java/org/whispersystems/textsecure/api/TextSecureAccountManager.java
@@ -131,6 +131,18 @@ public class TextSecureAccountManager {
   }
 
   /**
+   * Enable or disable the WebSocket channel with this account.
+   *
+   * @param enabled Whether or not the WebSocket channel should be enabled as a means to receive
+   *                messages. New accounts default to false.
+   *
+   * @throws IOException
+   */
+  public void setWebSocketChannelEnabled(boolean enabled) throws IOException {
+    this.pushServiceSocket.setWebSocketChannelEnabled(enabled);
+  }
+
+  /**
    * Register an identity key, last resort key, signed prekey, and list of one time prekeys
    * with the server.
    *

--- a/java/src/main/java/org/whispersystems/textsecure/internal/push/PushServiceSocket.java
+++ b/java/src/main/java/org/whispersystems/textsecure/internal/push/PushServiceSocket.java
@@ -78,6 +78,7 @@ public class PushServiceSocket {
   private static final String CREATE_ACCOUNT_VOICE_PATH = "/v1/accounts/voice/code/%s";
   private static final String VERIFY_ACCOUNT_PATH       = "/v1/accounts/code/%s";
   private static final String REGISTER_GCM_PATH         = "/v1/accounts/gcm/";
+  private static final String WEBSOCKETS_PATH           = "/v1/accounts/wsc/";
 
   private static final String PREKEY_METADATA_PATH      = "/v2/keys/";
   private static final String PREKEY_PATH               = "/v2/keys/%s";
@@ -112,6 +113,9 @@ public class PushServiceSocket {
     makeRequest(String.format(path, credentialsProvider.getUser()), "GET", null);
   }
 
+  public void setWebSocketChannelEnabled(boolean enabled) throws IOException {
+    makeRequest(WEBSOCKETS_PATH, enabled ? "PUT" : "DELETE", null);
+  }
   public void verifyAccount(String verificationCode, String signalingKey,
                             boolean supportsSms, int registrationId)
       throws IOException


### PR DESCRIPTION
My test bot wasn't able to receive messages without enabling websockets via this endpoint.

Tested by enabling (websocket receiving worked), as well as disabling (stopped working).