### PR TITLE
All telephone numbers in the Faroe Islands (+298) are 6 digits and th…

### DIFF
--- a/java/src/main/java/org/whispersystems/textsecure/api/util/PhoneNumberFormatter.java
+++ b/java/src/main/java/org/whispersystems/textsecure/api/util/PhoneNumberFormatter.java
@@ -36,7 +36,7 @@ public class PhoneNumberFormatter {
   private static final String TAG = PhoneNumberFormatter.class.getSimpleName();
 
   public static boolean isValidNumber(String number) {
-    return number.matches("^\\+[0-9]{10,}");
+    return number.matches("^\\+[0-9]{9,}");
   }
 
   private static String impreciseFormatNumber(String number, String localNumber)


### PR DESCRIPTION
All telephone numbers in the Faroe Islands (+298) are 6 digits and thus the current code fails every valid number.

Lowering the regexp limit to 9 digits would be appreciated very much. Thank you. :-)
